### PR TITLE
Add Destroy function to FGameLiftServerSDKModule

### DIFF
--- a/GameLiftPlugin/Source/GameLiftServer/Source/GameLiftServerSDK/Private/GameLiftServerSDK.cpp
+++ b/GameLiftPlugin/Source/GameLiftServer/Source/GameLiftServerSDK/Private/GameLiftServerSDK.cpp
@@ -179,6 +179,21 @@ FGameLiftGenericOutcome FGameLiftServerSDKModule::RemovePlayerSession(const FStr
 #endif
 }
 
+FGameLiftGenericOutcome FGameLiftServerSDKModule::Destroy()
+{
+#if WITH_GAMELIFT
+    auto outcome = Aws::GameLift::Server::Destroy();
+    if (outcome.IsSuccess()){
+        return FGameLiftGenericOutcome(nullptr);
+    }
+    else {
+        return FGameLiftGenericOutcome(FGameLiftError(outcome.GetError()));
+    }
+#else
+    return FGameLiftGenericOutcome(nullptr);
+#endif
+}
+
 FGameLiftDescribePlayerSessionsOutcome FGameLiftServerSDKModule::DescribePlayerSessions(const FGameLiftDescribePlayerSessionsRequest &describePlayerSessionsRequest)
 {
 #if WITH_GAMELIFT

--- a/GameLiftPlugin/Source/GameLiftServer/Source/GameLiftServerSDK/Public/GameLiftServerSDK.h
+++ b/GameLiftPlugin/Source/GameLiftServer/Source/GameLiftServerSDK/Public/GameLiftServerSDK.h
@@ -136,6 +136,7 @@ public:
     virtual FGameLiftGenericOutcome ActivateGameSession();
     virtual FGameLiftGenericOutcome AcceptPlayerSession(const FString& playerSessionId);
     virtual FGameLiftGenericOutcome RemovePlayerSession(const FString& playerSessionId);
+    virtual FGameLiftGenericOutcome Destroy();
     virtual FGameLiftDescribePlayerSessionsOutcome DescribePlayerSessions(const FGameLiftDescribePlayerSessionsRequest& describePlayerSessionsRequest);
 
     virtual FGameLiftGenericOutcome UpdatePlayerSessionCreationPolicy(EPlayerSessionCreationPolicy policy);


### PR DESCRIPTION
*I would like to propose adding the `Destroy()` function to the `FGameLiftServerSDKModule` module. Currently, this function is only available in the `GameLiftServerAPI` module. By adding it to `FGameLiftServerSDKModule`, we can provide a more consistent API for developers.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
