### PR TITLE
Disabling erroneous C5103 Warnings for macros.

### DIFF
--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/GameLiftPlugin.cpp
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/GameLiftPlugin.cpp
@@ -168,6 +168,7 @@ void FGameLiftPluginModule::RegisterMenuExtensions()
 		}), \
 		FCanExecuteAction())
 
+#pragma warning(disable:5103) //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 	MAP_ACTION(OpenSettings);
 	MAP_ACTION(DeployAnywhere);
 	MAP_ACTION(DeployManagedEC2);
@@ -177,6 +178,7 @@ void FGameLiftPluginModule::RegisterMenuExtensions()
 	MAP_HELP_URL_ACTION(ReportIssues);
 	MAP_HELP_URL_ACTION(OpenServiceAPIReference);
 	MAP_HELP_URL_ACTION(OpenServerSDKReference);
+	#pragma warning(default:5103) //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token	
 
 #undef MAP_ACTION
 #undef MAP_HELP_ACTION

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EAwsRegions.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EAwsRegions.h
@@ -92,6 +92,7 @@ namespace Aws
 
 		switch (InRegion)
 		{
+			_Pragma("warning(disable:5103)") //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 			CASE_REGION(us_east_2);
 			CASE_REGION(us_east_1);
 			CASE_REGION(us_west_1);
@@ -114,6 +115,7 @@ namespace Aws
 			CASE_REGION(eu_north_1);
 			CASE_REGION(me_south_1);
 			CASE_REGION(sa_east_1);
+			_Pragma("warning(default:5103)") //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 		default:
 			break;
 		}
@@ -129,6 +131,7 @@ namespace Aws
 
 		switch (InRegion)
 		{
+			_Pragma("warning(disable:5103)") //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 			CASE_REGION(us_east_2);
 			CASE_REGION(us_east_1);
 			CASE_REGION(us_west_1);
@@ -151,6 +154,7 @@ namespace Aws
 			CASE_REGION(eu_north_1);
 			CASE_REGION(me_south_1);
 			CASE_REGION(sa_east_1);
+			_Pragma("warning(default:5103)") //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 		default:
 			break;
 		}
@@ -166,6 +170,7 @@ namespace Aws
 
 		static std::unordered_map<std::wstring, ERegions> RegionMap
 		{
+			_Pragma("warning(disable:5103)") //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 			ADD_REGION(us_east_2),
 			ADD_REGION(us_east_1),
 			ADD_REGION(us_west_1),
@@ -188,6 +193,7 @@ namespace Aws
 			ADD_REGION(eu_north_1),
 			ADD_REGION(me_south_1),
 			ADD_REGION(sa_east_1)
+			_Pragma("warning(default:5103)") //C5103: Pasting <token1> and <token2> does not result in a valid preprocessing token
 		};
 		auto It = RegionMap.find(*InRegionString);
 		return It != RegionMap.end() ? It->second : ERegions::us_east_2;

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EBootstrapMessageState.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EBootstrapMessageState.h
@@ -22,7 +22,7 @@ constexpr auto EBootstrapMessageStateFromInt(int State)
 	return EBootstrapMessageState(State);
 }
 
-FText EBootstrapMessageStateToString(EBootstrapMessageState State)
+inline FText EBootstrapMessageStateToString(EBootstrapMessageState State)
 {
 	switch (State)
 	{


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
In UE 5.3.2 the following macros throw build warnings that are just log spam and not correct: MAP_HELP_URL_ACTION
ADD_REGION
CASE_REGION

Also, made EBootstrapMessageStateToString(EBootstrapMessageState State) inline to align it with the FString version and remove possible linker errors when used in static functions.

Tested as working on Win64 and Android using source UE 5.3.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
